### PR TITLE
See: agregar clave SOL

### DIFF
--- a/packages/lite/src/Greenter/Factory/FeFactory.php
+++ b/packages/lite/src/Greenter/Factory/FeFactory.php
@@ -22,28 +22,28 @@ use Greenter\XMLSecLibs\Sunat\SignedXml;
 class FeFactory implements FactoryInterface
 {
     /**
-     * @var SignedXml
+     * @var SignedXml|null
      */
     private $signer;
 
     /**
      * Sender service.
      *
-     * @var SenderInterface
+     * @var SenderInterface|null
      */
     private $sender;
 
     /**
      * Ultimo xml generado.
      *
-     * @var string
+     * @var string|null
      */
     private $lastXml;
 
     /**
      * Xml Builder.
      *
-     * @var BuilderInterface
+     * @var BuilderInterface|null
      */
     private $builder;
 
@@ -74,7 +74,7 @@ class FeFactory implements FactoryInterface
      *
      * @return FeFactory
      */
-    public function setSender(?SenderInterface $sender)
+    public function setSender(?SenderInterface $sender): self
     {
         $this->sender = $sender;
 
@@ -88,7 +88,7 @@ class FeFactory implements FactoryInterface
      *
      * @return FeFactory
      */
-    public function setBuilder(?BuilderInterface $builder)
+    public function setBuilder(?BuilderInterface $builder): self
     {
         $this->builder = $builder;
 
@@ -108,7 +108,7 @@ class FeFactory implements FactoryInterface
      *
      * @return FeFactory
      */
-    public function setSigner(?SignedXml $signer)
+    public function setSigner(?SignedXml $signer): self
     {
         $this->signer = $signer;
 
@@ -130,7 +130,7 @@ class FeFactory implements FactoryInterface
     }
 
 
-    public function sendXml(?string $name, ?string $xml)
+    public function sendXml(?string $name, ?string $xml): ?BaseResult
     {
         return $this->sender->send($name, $xml);
     }
@@ -150,7 +150,7 @@ class FeFactory implements FactoryInterface
      *
      * @return string
      */
-    public function getXmlSigned(DocumentInterface $document)
+    public function getXmlSigned(DocumentInterface $document): ?string
     {
         $xml = $this->builder->build($document);
 

--- a/packages/lite/src/Greenter/Factory/WsSenderResolver.php
+++ b/packages/lite/src/Greenter/Factory/WsSenderResolver.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenter\Factory;
+
+use Greenter\Model\DocumentInterface;
+use Greenter\Model\Summary\Summary;
+use Greenter\Model\Voided\Reversion;
+use Greenter\Model\Voided\Voided;
+use Greenter\Services\SenderInterface;
+use Greenter\Validator\ErrorCodeProviderInterface;
+use Greenter\Ws\Services\BillSender;
+use Greenter\Ws\Services\SummarySender;
+use Greenter\Ws\Services\WsClientInterface;
+
+class WsSenderResolver
+{
+    /**
+     * @var string[]
+     */
+    private $summary;
+    /**
+     * @var WsClientInterface
+     */
+    private $client;
+    /**
+     * @var ErrorCodeProviderInterface|null
+     */
+    private $codeProvider;
+
+    /**
+     * WsSenderResolver constructor.
+     * @param WsClientInterface $client
+     * @param ErrorCodeProviderInterface|null $codeProvider
+     */
+    public function __construct(WsClientInterface $client, ?ErrorCodeProviderInterface $codeProvider)
+    {
+        $this->client = $client;
+        $this->codeProvider = $codeProvider;
+        $this->summary = [
+            Summary::class,
+            Voided::class,
+            Reversion::class
+        ];
+    }
+
+    public function find(DocumentInterface $document): SenderInterface
+    {
+        $docClass = get_class($document);
+        $sender = in_array($docClass, $this->summary) ? new SummarySender() : new BillSender();
+        $sender->setClient($this->client);
+        $sender->setCodeProvider($this->codeProvider);
+
+        return $sender;
+    }
+}

--- a/packages/lite/src/Greenter/Factory/WsSenderResolver.php
+++ b/packages/lite/src/Greenter/Factory/WsSenderResolver.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Greenter\Factory;
 
-use Greenter\Model\DocumentInterface;
 use Greenter\Model\Summary\Summary;
 use Greenter\Model\Voided\Reversion;
 use Greenter\Model\Voided\Voided;
@@ -45,9 +44,8 @@ class WsSenderResolver
         ];
     }
 
-    public function find(DocumentInterface $document): SenderInterface
+    public function find(string $docClass): SenderInterface
     {
-        $docClass = get_class($document);
         $sender = in_array($docClass, $this->summary) ? new SummarySender() : new BillSender();
         $sender->setClient($this->client);
         $sender->setCodeProvider($this->codeProvider);

--- a/packages/lite/src/Greenter/Factory/XmlBuilderResolver.php
+++ b/packages/lite/src/Greenter/Factory/XmlBuilderResolver.php
@@ -9,10 +9,6 @@ use Greenter\Builder\BuilderInterface;
 class XmlBuilderResolver
 {
     /**
-     * @var string[]
-     */
-    private $builders;
-    /**
      * @var array
      */
     private $options;
@@ -24,22 +20,19 @@ class XmlBuilderResolver
     public function __construct(array $options = [])
     {
         $this->options = $options;
-        $this->builders = [
-            \Greenter\Model\Sale\Invoice::class => \Greenter\Xml\Builder\InvoiceBuilder::class,
-            \Greenter\Model\Sale\Note::class => \Greenter\Xml\Builder\NoteBuilder::class,
-            \Greenter\Model\Summary\Summary::class => \Greenter\Xml\Builder\SummaryBuilder::class,
-            \Greenter\Model\Voided\Voided::class => \Greenter\Xml\Builder\VoidedBuilder::class,
-            \Greenter\Model\Despatch\Despatch::class => \Greenter\Xml\Builder\DespatchBuilder::class,
-            \Greenter\Model\Retention\Retention::class => \Greenter\Xml\Builder\RetentionBuilder::class,
-            \Greenter\Model\Perception\Perception::class => \Greenter\Xml\Builder\PerceptionBuilder::class,
-            \Greenter\Model\Voided\Reversion::class => \Greenter\Xml\Builder\VoidedBuilder::class,
-        ];
     }
 
     public function find(string $docClass): BuilderInterface
     {
-        $builder = $this->builders[$docClass];
+        $builder = $this->findBuilderType($docClass);
 
         return new $builder($this->options);
+    }
+
+    private function findBuilderType(string $docClass): string
+    {
+        $className = substr(strrchr($docClass, '\\'), 1);
+
+        return "Greenter\\Xml\\Builder\\${className}Builder";
     }
 }

--- a/packages/lite/src/Greenter/Factory/XmlBuilderResolver.php
+++ b/packages/lite/src/Greenter/Factory/XmlBuilderResolver.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenter\Factory;
+
+use Greenter\Builder\BuilderInterface;
+
+class XmlBuilderResolver
+{
+    /**
+     * @var string[]
+     */
+    private $builders;
+    /**
+     * @var array
+     */
+    private $options;
+
+    /**
+     * XmlBuilderResolver constructor.
+     * @param array $options
+     */
+    public function __construct(array $options = [])
+    {
+        $this->options = $options;
+        $this->builders = [
+            \Greenter\Model\Sale\Invoice::class => \Greenter\Xml\Builder\InvoiceBuilder::class,
+            \Greenter\Model\Sale\Note::class => \Greenter\Xml\Builder\NoteBuilder::class,
+            \Greenter\Model\Summary\Summary::class => \Greenter\Xml\Builder\SummaryBuilder::class,
+            \Greenter\Model\Voided\Voided::class => \Greenter\Xml\Builder\VoidedBuilder::class,
+            \Greenter\Model\Despatch\Despatch::class => \Greenter\Xml\Builder\DespatchBuilder::class,
+            \Greenter\Model\Retention\Retention::class => \Greenter\Xml\Builder\RetentionBuilder::class,
+            \Greenter\Model\Perception\Perception::class => \Greenter\Xml\Builder\PerceptionBuilder::class,
+            \Greenter\Model\Voided\Reversion::class => \Greenter\Xml\Builder\VoidedBuilder::class,
+        ];
+    }
+
+    public function find(string $docClass): BuilderInterface
+    {
+        $builder = $this->builders[$docClass];
+
+        return new $builder($this->options);
+    }
+}

--- a/packages/lite/src/Greenter/See.php
+++ b/packages/lite/src/Greenter/See.php
@@ -106,6 +106,18 @@ class See
     }
 
     /**
+     * Set Clave SOL de usuario secundario.
+     *
+     * @param string $ruc
+     * @param string $user
+     * @param string $password
+     */
+    public function setClaveSOL(string $ruc, string $user, string $password)
+    {
+        $this->wsClient->setCredentials($ruc.$user, $password);
+    }
+
+    /**
      * @param string $service
      */
     public function setService(?string $service)

--- a/packages/lite/src/Greenter/See.php
+++ b/packages/lite/src/Greenter/See.php
@@ -12,21 +12,16 @@ namespace Greenter;
 
 use DOMDocument;
 use Exception;
-use Greenter\Builder\BuilderInterface;
 use Greenter\Factory\FeFactory;
+use Greenter\Factory\WsSenderResolver;
+use Greenter\Factory\XmlBuilderResolver;
 use Greenter\Model\DocumentInterface;
-use Greenter\Model\Summary\Summary;
-use Greenter\Model\Voided\Reversion;
-use Greenter\Model\Voided\Voided;
-use Greenter\Services\SenderInterface;
 use Greenter\Validator\ErrorCodeProviderInterface;
 use Greenter\Ws\Reader\XmlFilenameExtractor;
 use Greenter\Ws\Reader\XmlReader;
 use Greenter\Ws\Resolver\XmlTypeResolver;
-use Greenter\Ws\Services\BillSender;
 use Greenter\Ws\Services\ExtService;
 use Greenter\Ws\Services\SoapClient;
-use Greenter\Ws\Services\SummarySender;
 use Greenter\XMLSecLibs\Sunat\SignedXml;
 
 /**
@@ -45,16 +40,6 @@ class See
      * @var SoapClient
      */
     private $wsClient;
-
-    /**
-     * @var array
-     */
-    private $builders;
-
-    /**
-     * @var array
-     */
-    private $summarys;
 
     /**
      * @var SignedXml
@@ -81,17 +66,6 @@ class See
         $this->factory = new FeFactory();
         $this->wsClient = new SoapClient();
         $this->signer = new SignedXml();
-        $this->builders = [
-            Model\Sale\Invoice::class => Xml\Builder\InvoiceBuilder::class,
-            Model\Sale\Note::class => Xml\Builder\NoteBuilder::class,
-            Model\Summary\Summary::class => Xml\Builder\SummaryBuilder::class,
-            Model\Voided\Voided::class => Xml\Builder\VoidedBuilder::class,
-            Model\Despatch\Despatch::class => Xml\Builder\DespatchBuilder::class,
-            Model\Retention\Retention::class => Xml\Builder\RetentionBuilder::class,
-            Model\Perception\Perception::class => Xml\Builder\PerceptionBuilder::class,
-            Model\Voided\Reversion::class => Xml\Builder\VoidedBuilder::class,
-        ];
-        $this->summarys = [Summary::class, Summary::class, Voided::class, Reversion::class];
         $this->factory->setSigner($this->signer);
     }
 
@@ -141,7 +115,7 @@ class See
     /**
      * Set error code provider.
      *
-     * @param ErrorCodeProviderInterface $codeProvider
+     * @param ErrorCodeProviderInterface|null $codeProvider
      */
     public function setCodeProvider(?ErrorCodeProviderInterface $codeProvider)
     {
@@ -157,10 +131,10 @@ class See
      */
     public function getXmlSigned(DocumentInterface $document)
     {
-        $classDoc = get_class($document);
+        $buildResolver = new XmlBuilderResolver($this->options);
 
         return $this->factory
-            ->setBuilder($this->getBuilder($classDoc))
+            ->setBuilder($buildResolver->find(get_class($document)))
             ->getXmlSigned($document);
     }
 
@@ -173,10 +147,7 @@ class See
      */
     public function send(DocumentInterface $document)
     {
-        $classDoc = get_class($document);
-        $this->factory
-            ->setBuilder($this->getBuilder($classDoc))
-            ->setSender($this->getSender($classDoc));
+        $this->configureFactory(get_class($document));
 
         return $this->factory->send($document);
     }
@@ -192,9 +163,7 @@ class See
      */
     public function sendXml(string $type, string $name, string $xml)
     {
-        $this->factory
-            ->setBuilder($this->getBuilder($type))
-            ->setSender($this->getSender($type));
+        $this->configureFactory($type);
 
         return $this->factory->sendXml($name, $xml);
     }
@@ -227,6 +196,7 @@ class See
      * @param string|null $ticket
      *
      * @return Model\Response\StatusResult
+     * @throws Exception
      */
     public function getStatus(?string $ticket)
     {
@@ -239,36 +209,18 @@ class See
     /**
      * @return FeFactory
      */
-    public function getFactory()
+    public function getFactory(): FeFactory
     {
         return $this->factory;
     }
 
-    /**
-     * @param string $class
-     *
-     * @return BuilderInterface
-     */
-    private function getBuilder(string $class)
+    private function configureFactory(string $docClass)
     {
-        $builder = $this->builders[$class];
+        $buildResolver = new XmlBuilderResolver($this->options);
+        $senderResolver = new WsSenderResolver($this->wsClient, $this->codeProvider);
 
-        return new $builder($this->options);
-    }
-
-    /**
-     * @param string $class
-     *
-     * @return SenderInterface
-     */
-    private function getSender(string $class)
-    {
-        $sender = in_array($class, $this->summarys) ? new SummarySender() : new BillSender();
-        $sender->setClient($this->wsClient);
-        if ($this->codeProvider) {
-            $sender->setCodeProvider($this->codeProvider);
-        }
-
-        return $sender;
+        $this->factory
+            ->setBuilder($buildResolver->find($docClass))
+            ->setSender($senderResolver->find($docClass));
     }
 }

--- a/packages/lite/src/Greenter/See.php
+++ b/packages/lite/src/Greenter/See.php
@@ -16,6 +16,7 @@ use Greenter\Factory\FeFactory;
 use Greenter\Factory\WsSenderResolver;
 use Greenter\Factory\XmlBuilderResolver;
 use Greenter\Model\DocumentInterface;
+use Greenter\Model\Response\StatusResult;
 use Greenter\Validator\ErrorCodeProviderInterface;
 use Greenter\Ws\Reader\XmlFilenameExtractor;
 use Greenter\Ws\Reader\XmlReader;
@@ -195,10 +196,10 @@ class See
     /**
      * @param string|null $ticket
      *
-     * @return Model\Response\StatusResult
+     * @return StatusResult
      * @throws Exception
      */
-    public function getStatus(?string $ticket)
+    public function getStatus(?string $ticket): StatusResult
     {
         $sender = new ExtService();
         $sender->setClient($this->wsClient);
@@ -214,7 +215,7 @@ class See
         return $this->factory;
     }
 
-    private function configureFactory(string $docClass)
+    private function configureFactory(string $docClass): void
     {
         $buildResolver = new XmlBuilderResolver($this->options);
         $senderResolver = new WsSenderResolver($this->wsClient, $this->codeProvider);

--- a/packages/lite/tests/Greenter/SeeFeTest.php
+++ b/packages/lite/tests/Greenter/SeeFeTest.php
@@ -181,7 +181,7 @@ class SeeFeTest extends FeFactoryBase
         ]);
         $see->setCachePath(null);
         $see->setCodeProvider($this->getErrorCodeProvider());
-        $see->setCredentials('20000000001MODDATOS', 'moddatos');
+        $see->setClaveSOL('20000000001', 'MODDATOS', 'moddatos');
         $see->setCertificate(file_get_contents(__DIR__.'/../Resources/SFSCert.pem'));
 
         return $see;

--- a/packages/ws/src/Ws/Services/BaseSunat.php
+++ b/packages/ws/src/Ws/Services/BaseSunat.php
@@ -65,7 +65,7 @@ class BaseSunat
     /**
      * @return WsClientInterface
      */
-    public function getClient()
+    public function getClient(): WsClientInterface
     {
         return $this->client;
     }
@@ -75,7 +75,7 @@ class BaseSunat
      *
      * @return BaseSunat
      */
-    public function setClient($client)
+    public function setClient(WsClientInterface $client)
     {
         $this->client = $client;
 

--- a/packages/ws/src/Ws/Services/BaseSunat.php
+++ b/packages/ws/src/Ws/Services/BaseSunat.php
@@ -55,9 +55,9 @@ class BaseSunat
     public $cdrReader;
 
     /**
-     * @param ErrorCodeProviderInterface $codeProvider
+     * @param ErrorCodeProviderInterface|null $codeProvider
      */
-    public function setCodeProvider(ErrorCodeProviderInterface $codeProvider)
+    public function setCodeProvider(?ErrorCodeProviderInterface $codeProvider)
     {
         $this->codeProvider = $codeProvider;
     }
@@ -162,7 +162,7 @@ class BaseSunat
      */
     protected function getMessageError($code)
     {
-        if (empty($this->codeProvider)) {
+        if (is_null($this->codeProvider)) {
             return '';
         }
 

--- a/packages/ws/src/Ws/Services/BaseSunat.php
+++ b/packages/ws/src/Ws/Services/BaseSunat.php
@@ -162,7 +162,7 @@ class BaseSunat
      */
     protected function getMessageError($code)
     {
-        if (is_null($this->codeProvider)) {
+        if ($this->codeProvider === null) {
             return '';
         }
 

--- a/packages/ws/src/Ws/Services/ExtService.php
+++ b/packages/ws/src/Ws/Services/ExtService.php
@@ -25,7 +25,7 @@ class ExtService extends BaseSunat
      * @return StatusResult
      * @throws Exception
      */
-    public function getStatus($ticket)
+    public function getStatus($ticket): StatusResult
     {
         try {
             return $this->getStatusInternal($ticket);
@@ -37,7 +37,7 @@ class ExtService extends BaseSunat
         }
     }
 
-    private function getStatusInternal($ticket)
+    private function getStatusInternal($ticket): StatusResult
     {
         $params = [
             'ticket' => $ticket,
@@ -51,7 +51,7 @@ class ExtService extends BaseSunat
         return $this->processResponse($response->status);
     }
 
-    private function processResponse($status)
+    private function processResponse($status): StatusResult
     {
         $originCode = $status->statusCode;
         $code = (int)$originCode;
@@ -87,20 +87,18 @@ class ExtService extends BaseSunat
      *
      * @return Error
      */
-    private function getCustomError($code)
+    private function getCustomError($code): Error
     {
-        $error = new Error($code, 'El procesamiento del comprobante aún no ha terminado');
-
-        return $error;
+        return new Error($code, 'El procesamiento del comprobante aún no ha terminado');
     }
 
-    private function isProcessed($code)
+    private function isProcessed(int $code)
     {
-        return '0' == $code || '99' == $code;
+        return 0 === $code || 99 === $code;
     }
 
-    private function isPending($code)
+    private function isPending(int $code)
     {
-        return '98' == $code;
+        return 98 === $code;
     }
 }


### PR DESCRIPTION
Se reescribe `See` para agregar un nuevo método `setClaveSOL`, debido a confusiones con el método `setCredentials`. 