### PR TITLE
Zip in memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Puede ver una demostración en [@greenter/demo](https://github.com/thegreenter/d
 
 ## Requerimientos
 - PHP `7.2` o superior
-- Extensiones PHP Activadas: `soap`, `zip`, `zlib`, `openssl`.
+- Extensiones PHP Activadas: `soap`, `zlib`, `openssl`.
 
 ## Documentación
 - Lee esta [guia](https://fe-primer.greenter.dev/) para conocer mas sobre facturación electrónica.

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "bacon/bacon-qr-code": "^2.0",
         "greenter/xmldsig": "^5.0",
         "mikehaertl/phpwkhtmltopdf": "^2.4",
+        "nelexa/zip": "^3.3",
         "symfony/validator": "^5.0",
         "twig/twig": "~3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "php": "^7.2",
         "ext-dom": "*",
         "ext-soap": "*",
-        "ext-zip": "*",
         "ext-zlib": "*",
         "bacon/bacon-qr-code": "^2.0",
         "greenter/xmldsig": "^5.0",

--- a/packages/ws/composer.json
+++ b/packages/ws/composer.json
@@ -20,7 +20,8 @@
         "ext-zlib": "*",
         "ext-dom": "*",
         "ext-soap": "*",
-        "greenter/core": "^4.1"
+        "greenter/core": "^4.1",
+        "nelexa/zip": "^3.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^8",

--- a/packages/ws/composer.json
+++ b/packages/ws/composer.json
@@ -16,7 +16,6 @@
     "type": "library",
     "require": {
         "php": "^7.2",
-        "ext-zip": "*",
         "ext-zlib": "*",
         "ext-dom": "*",
         "ext-soap": "*",

--- a/packages/ws/src/Ws/Services/BaseSunat.php
+++ b/packages/ws/src/Ws/Services/BaseSunat.php
@@ -18,6 +18,7 @@ use Greenter\Ws\Reader\DomCdrReader;
 use Greenter\Ws\Reader\XmlReader;
 use Greenter\Zip\CompressInterface;
 use Greenter\Zip\DecompressInterface;
+use Greenter\Zip\ZipDecompressDecorator;
 use Greenter\Zip\ZipFly;
 use SoapFault;
 
@@ -191,7 +192,7 @@ class BaseSunat
     private function getXmlResponse($content)
     {
         if (!$this->decompressor) {
-            $this->decompressor = new ZipFly();
+            $this->decompressor = new ZipDecompressDecorator(new ZipFly());
         }
 
         $filter = function ($filename) {

--- a/packages/ws/src/Ws/Services/BaseSunat.php
+++ b/packages/ws/src/Ws/Services/BaseSunat.php
@@ -18,7 +18,6 @@ use Greenter\Ws\Reader\DomCdrReader;
 use Greenter\Ws\Reader\XmlReader;
 use Greenter\Zip\CompressInterface;
 use Greenter\Zip\DecompressInterface;
-use Greenter\Zip\ZipFileDecompress;
 use Greenter\Zip\ZipFly;
 use SoapFault;
 
@@ -192,7 +191,7 @@ class BaseSunat
     private function getXmlResponse($content)
     {
         if (!$this->decompressor) {
-            $this->decompressor = new ZipFileDecompress();
+            $this->decompressor = new ZipFly();
         }
 
         $filter = function ($filename) {

--- a/packages/ws/src/Zip/ZipDecompressDecorator.php
+++ b/packages/ws/src/Zip/ZipDecompressDecorator.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenter\Zip;
+
+use Exception;
+
+class ZipDecompressDecorator implements DecompressInterface
+{
+    /**
+     * @var DecompressInterface
+     */
+    private $decompressor;
+
+    /**
+     * ZipDecompressDecorator constructor.
+     * @param DecompressInterface $decompressor
+     */
+    public function __construct(DecompressInterface $decompressor)
+    {
+        $this->decompressor = $decompressor;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function decompress(?string $content, callable $filter = null): ?array
+    {
+        if (empty($content)) {
+            return [];
+        }
+
+        try {
+            return $this->decompressor->decompress($content, $filter);
+        } catch (Exception $e) {
+            return [];
+        }
+    }
+}

--- a/packages/ws/src/Zip/ZipFileDecompress.php
+++ b/packages/ws/src/Zip/ZipFileDecompress.php
@@ -12,6 +12,7 @@ use ZipArchive;
 
 /**
  * Class ZipFileDecompress.
+ * @deprecated deprecated since version v4.0.3, use ZipFlyDecompress
  */
 class ZipFileDecompress implements DecompressInterface
 {

--- a/packages/ws/src/Zip/ZipFly.php
+++ b/packages/ws/src/Zip/ZipFly.php
@@ -8,156 +8,14 @@
 
 namespace Greenter\Zip;
 
+use Exception;
+use PhpZip\ZipFile;
+
 /**
  * Class ZipFile.
  */
 class ZipFly implements CompressInterface, DecompressInterface
 {
-    const UNZIP_FORMAT = 'Vsig/vver/vflag/vmeth/vmodt/vmodd/Vcrc/Vcsize/Vsize/vnamelen/vexlen';
-
-    /**
-     * Array to store compressed data.
-     *
-     * @private  array    $datasec
-     */
-    private $datasec;
-    /**
-     * Central directory.
-     *
-     * @private  array    $ctrl_dir
-     */
-    private $ctrl_dir;
-    /**
-     * End of central directory record.
-     *
-     * @private  string   $eof_ctrl_dir
-     */
-    private $eof_ctrl_dir = "\x50\x4b\x05\x06\x00\x00\x00\x00";
-    /**
-     * Last offset position.
-     *
-     * @private  integer  $old_offset
-     */
-    private $old_offset;
-
-    /**
-     * ZipFly constructor.
-     */
-    public function __construct()
-    {
-        $this->clear();
-    }
-
-    /**
-     * Converts an Unix timestamp to a four byte DOS date and time format (date
-     * in high two bytes, time in low two bytes allowing magnitude comparison).
-     *
-     * @param int $unixtime the current Unix timestamp
-     *
-     * @return int the current date in a four byte DOS format
-     */
-    public function unix2DosTime($unixtime = 0)
-    {
-        $timearray = (0 == $unixtime) ? getdate() : getdate($unixtime);
-        if ($timearray['year'] < 1980) {
-            $timearray['year'] = 1980;
-            $timearray['mon'] = 1;
-            $timearray['mday'] = 1;
-            $timearray['hours'] = 0;
-            $timearray['minutes'] = 0;
-            $timearray['seconds'] = 0;
-        } // end if
-        return (($timearray['year'] - 1980) << 25)
-            | ($timearray['mon'] << 21)
-            | ($timearray['mday'] << 16)
-            | ($timearray['hours'] << 11)
-            | ($timearray['minutes'] << 5)
-            | ($timearray['seconds'] >> 1);
-    }
-
-    /**
-     * Adds "file" to archive.
-     *
-     * @param string $data file contents
-     * @param string $name name of the file in the archive (may contains the path)
-     * @param int    $time the current timestamp
-     */
-    public function addFile($data, $name, $time = 0)
-    {
-        $name = str_replace('\\', '/', $name);
-        $hexdtime = pack('V', $this->unix2DosTime($time));
-        $frd = "\x50\x4b\x03\x04";
-        $frd .= "\x14\x00";            // ver needed to extract
-        $frd .= "\x00\x00";            // gen purpose bit flag
-        $frd .= "\x08\x00";            // compression method
-        $frd .= $hexdtime;             // last mod time and date
-        // "local file header" segment
-        list($zdata, $part) = $this->getPartsFromData($data, $name);
-
-        $frd .= $part.$name;
-        // "file data" segment
-        $frd .= $zdata;
-        // echo this entry on the fly, ...
-        $this->datasec[] = $frd;
-        // now add to central directory record
-        $cdrec = "\x50\x4b\x01\x02";
-        $cdrec .= "\x00\x00";                // version made by
-        $cdrec .= "\x14\x00";                // version needed to extract
-        $cdrec .= "\x00\x00";                // gen purpose bit flag
-        $cdrec .= "\x08\x00";                // compression method
-        $cdrec .= $hexdtime;                 // last mod time & date
-        $cdrec .= $part;
-        // file comment length, disk number start, internal file attributes
-        $cdrec .= str_repeat(pack('v', 0), 3);
-        $cdrec .= pack('V', 32);            // external file attributes
-        // - 'archive' bit set
-        $cdrec .= pack('V', $this->old_offset); // relative offset of local header
-        $this->old_offset += strlen($frd);
-        $cdrec .= $name;
-        // optional extra field, file comment goes here
-        // save to central directory
-        $this->ctrl_dir[] = $cdrec;
-    }
-
-    private function getPartsFromData($data, $name)
-    {
-        $zdata = gzcompress($data);
-        $zdata = substr(substr($zdata, 0, strlen($zdata) - 4), 2); // fix crc bug
-        $unc_len = strlen($data);
-        $crc = crc32($data);
-        $c_len = strlen($zdata);
-
-        $frd = pack('V', $crc);             // crc32
-        $frd .= pack('V', $c_len);          // compressed filesize
-        $frd .= pack('V', $unc_len);        // uncompressed filesize
-        $frd .= pack('v', strlen($name));   // length of filename
-        $frd .= pack('v', 0);         // extra field length
-
-        return [$zdata, $frd];
-    }
-
-    /**
-     * Echo central dir if ->doWrite==true, else build string to return.
-     *
-     * @return string if ->doWrite {empty string} else the ZIP file contents
-     */
-    public function file()
-    {
-        $ctrldir = implode('', $this->ctrl_dir);
-        $header = $ctrldir.
-            $this->eof_ctrl_dir.
-            pack('v', sizeof($this->ctrl_dir)). //total #of entries "on this disk"
-            pack('v', sizeof($this->ctrl_dir)). //total #of entries overall
-            pack('V', strlen($ctrldir)).          //size of central dir
-            pack('V', $this->old_offset).       //offset to start of central dir
-            "\x00\x00";                            //.zip file comment length
-
-        // Return entire ZIP archive as string
-        $data = implode('', $this->datasec);
-
-        return $data.$header;
-    }
-
     /**
      * Comprime el contenido del archivo con el nombre especifico y retorna el contenido del zip.
      *
@@ -168,22 +26,16 @@ class ZipFly implements CompressInterface, DecompressInterface
      */
     public function compress(?string $filename, ?string $content): ?string
     {
-        $this->addFile($content, $filename);
-        $zip = $this->file();
-        $this->clear();
+        $zipFile = new ZipFile();
+        $zipFile->addFromString($filename, $content);
+        $zip = $zipFile->outputAsString();
+        $zipFile->close();
 
         return $zip;
     }
 
-    private function clear()
-    {
-        $this->datasec = [];
-        $this->ctrl_dir = [];
-        $this->old_offset = 0;
-    }
-
     /**
-     * Extract files.
+     * Extract files by filter.
      *
      * @param string        $content
      * @param callable|null $filter
@@ -192,32 +44,47 @@ class ZipFly implements CompressInterface, DecompressInterface
      */
     public function decompress(?string $content, callable $filter = null): ?array
     {
-        $start = 0;
-        $result = [];
+        $zipFile = $this->openZip($content);
 
-        while (true) {
-            $dat = substr($content, $start, 30);
-            if (empty($dat)) {
-                break;
-            }
-
-            $head = unpack(self::UNZIP_FORMAT, $dat);
-            $filename = substr(substr($content, $start), 30, $head['namelen']);
-            if (empty($filename)) {
-                break;
-            }
-            $count = 30 + $head['namelen'] + $head['exlen'];
-
-            if (!$filter || $filter($filename)) {
-                $result[] = [
-                    'filename' => $filename,
-                    'content' => gzinflate(substr($content, $start + $count, $head['csize'])),
-                ];
-            }
-
-            $start += $count + $head['csize'];
+        $output = [];
+        if ($zipFile === null) {
+            return $output;
         }
 
-        return $result;
+        if ($zipFile->count() > 0) {
+            $output = iterator_to_array($this->getFiles($zipFile, $filter));
+        }
+
+        $zipFile->close();
+
+        return $output;
+    }
+
+    private function getFiles(ZipFile $zip, $filter)
+    {
+        $entries = $zip->getEntries();
+        foreach ($entries as $entry) {
+            $filename = $entry->getName();
+            if (!$filter || $filter($filename)) {
+                yield [
+                    'filename' => $filename,
+                    'content' => $zip->getEntryContents($filename),
+                ];
+            }
+        }
+    }
+
+    private function openZip(?string $zip): ?ZipFile
+    {
+        if (empty($zip)) {
+            return null;
+        }
+
+        try {
+            $zipFile = new ZipFile();
+            return $zipFile->openFromString($zip);
+        } catch (Exception $e) {
+            return null;
+        }
     }
 }

--- a/packages/ws/src/Zip/ZipFly.php
+++ b/packages/ws/src/Zip/ZipFly.php
@@ -8,7 +8,6 @@
 
 namespace Greenter\Zip;
 
-use Exception;
 use PhpZip\ZipFile;
 
 /**
@@ -44,13 +43,10 @@ class ZipFly implements CompressInterface, DecompressInterface
      */
     public function decompress(?string $content, callable $filter = null): ?array
     {
-        $zipFile = $this->openZip($content);
+        $zipFile = new ZipFile();
+        $zipFile->openFromString($content);
 
         $output = [];
-        if ($zipFile === null) {
-            return $output;
-        }
-
         if ($zipFile->count() > 0) {
             $output = iterator_to_array($this->getFiles($zipFile, $filter));
         }
@@ -71,20 +67,6 @@ class ZipFly implements CompressInterface, DecompressInterface
                     'content' => $zip->getEntryContents($filename),
                 ];
             }
-        }
-    }
-
-    private function openZip(?string $zip): ?ZipFile
-    {
-        if (empty($zip)) {
-            return null;
-        }
-
-        try {
-            $zipFile = new ZipFile();
-            return $zipFile->openFromString($zip);
-        } catch (Exception $e) {
-            return null;
         }
     }
 }

--- a/packages/ws/tests/Ws/Zip/ZipFactoryTest.php
+++ b/packages/ws/tests/Ws/Zip/ZipFactoryTest.php
@@ -12,6 +12,7 @@ namespace Tests\Greenter\Ws\Zip;
 
 use Greenter\Zip\ZipFly;
 use PHPUnit\Framework\TestCase;
+use PhpZip\Exception\InvalidArgumentException as InvalidArgumentExceptionPhpZip;
 
 /**
  * Class ZipFactoryTest.
@@ -52,6 +53,7 @@ class ZipFactoryTest extends TestCase
 
     public function testInvalidZip()
     {
+        $this->expectException(InvalidArgumentExceptionPhpZip::class);
         $zip = new ZipFly();
         $res = $zip->decompress('');
 

--- a/packages/ws/tests/Ws/Zip/ZipFactoryTest.php
+++ b/packages/ws/tests/Ws/Zip/ZipFactoryTest.php
@@ -50,14 +50,6 @@ class ZipFactoryTest extends TestCase
         $this->assertEquals(self::DATA_XML, $content);
     }
 
-    public function testUnixTime()
-    {
-        $zip = new ZipFly();
-        $result = $zip->unix2DosTime(181233012);
-
-        $this->assertEquals(2162688, $result);
-    }
-
     public function testInvalidZip()
     {
         $zip = new ZipFly();

--- a/packages/ws/tests/Ws/Zip/ZipFileDecompressTest.php
+++ b/packages/ws/tests/Ws/Zip/ZipFileDecompressTest.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 namespace Tests\Greenter\Ws\Zip;
 
 use Greenter\Zip\DecompressInterface;
-use Greenter\Zip\ZipFileDecompress;
 use Greenter\Zip\ZipFly;
 use PHPUnit\Framework\TestCase;
 
@@ -27,12 +26,19 @@ class ZipFileDecompressTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->zip = new ZipFileDecompress();
+        $this->zip = new ZipFly();
     }
 
     public function testDecompressEmptyFile()
     {
         $items = $this->zip->decompress('');
+
+        $this->assertEquals(0, count($items));
+    }
+
+    public function testDecompressInvalidZipFile()
+    {
+        $items = $this->zip->decompress('xxx');
 
         $this->assertEquals(0, count($items));
     }

--- a/packages/ws/tests/Ws/Zip/ZipFileDecompressTest.php
+++ b/packages/ws/tests/Ws/Zip/ZipFileDecompressTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace Tests\Greenter\Ws\Zip;
 
 use Greenter\Zip\DecompressInterface;
+use Greenter\Zip\ZipDecompressDecorator;
 use Greenter\Zip\ZipFly;
 use PHPUnit\Framework\TestCase;
 
@@ -26,7 +27,7 @@ class ZipFileDecompressTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->zip = new ZipFly();
+        $this->zip = new ZipDecompressDecorator(new ZipFly());
     }
 
     public function testDecompressEmptyFile()


### PR DESCRIPTION
close #131 
- `ext-zip` ya no es requerido
- Uso de implementación de compresion/decompresion en memoria, evitando escribir archivos temporales.
