### PR TITLE
Permitir instalación en PHP 8

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -24,7 +24,8 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
-        extensions: mbstring, soap
+        # zip only for linter
+        extensions: mbstring, soap, zip
 
     - name: Validate composer.json
       run: composer validate

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,8 +8,17 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        php: ['7.2', '8.0']
+        report-coverage: [false]
+        psalm-flags: ['']
+        include:
+          - os: ubuntu-20.04
+            php: '7.2'
+            report-coverage: true
+            psalm-flags: '--shepherd'
 
     steps:
     - uses: actions/checkout@v2
@@ -17,7 +26,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 7.2
+        php-version: ${{ matrix.php }}
         extensions: mbstring,soap
 
     - name: Validate composer.json
@@ -30,13 +39,15 @@ jobs:
       run: composer run-script lint:ci
 
     - name: Run PSalm
-      run: vendor/bin/psalm --shepherd
+      run: vendor/bin/psalm ${{ matrix.psalm-flags }}
 
     - name: Unit Tests
       run: vendor/bin/phpunit --exclude-group manual --coverage-clover clover.xml
 
     - uses: codecov/codecov-action@v1
+      if: ${{ matrix.report-coverage }}
       with:
         file: ./clover.xml
         flags: unittests
         name: codecov-greenter
+

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,11 +13,9 @@ jobs:
       matrix:
         php: ['8.0']
         report-coverage: [false]
-        psalm-flags: ['']
         include:
           - php: '7.2'
             report-coverage: true
-            psalm-flags: '--shepherd'
 
     steps:
     - uses: actions/checkout@v2
@@ -32,13 +30,14 @@ jobs:
       run: composer validate
 
     - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-suggest
+      run: composer install --prefer-dist --no-progress
 
     - name: Run PHPStan
       run: composer run-script lint:ci
 
     - name: Run PSalm
-      run: vendor/bin/psalm ${{ matrix.psalm-flags }}
+      if: ${{ matrix.report-coverage }}
+      run: vendor/bin/psalm --shepherd
 
     - name: Unit Tests
       run: vendor/bin/phpunit --exclude-group manual --coverage-clover clover.xml

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
         # zip only for linter
-        extensions: mbstring, soap, zip
+        extensions: mbstring, soap, :fileinfo, zip
 
     - name: Validate composer.json
       run: composer validate

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,12 +11,11 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php: ['7.2', '8.0']
+        php: ['8.0']
         report-coverage: [false]
         psalm-flags: ['']
         include:
-          - os: ubuntu-20.04
-            php: '7.2'
+          - php: '7.2'
             report-coverage: true
             psalm-flags: '--shepherd'
 
@@ -27,7 +26,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
-        extensions: mbstring,soap
+        extensions: mbstring, soap
 
     - name: Validate composer.json
       run: composer validate

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "bacon/bacon-qr-code": "^2.0",
         "greenter/xmldsig": "^5.0",
         "mikehaertl/phpwkhtmltopdf": "^2.4",
-        "nelexa/zip": "^3.3",
+        "nelexa/zip": "^3.3 || ^4.0",
         "symfony/validator": "^5.0",
         "twig/twig": "~3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,6 @@
     "suggest": {
         "ext-dom": "For xml, xml-parser, cpe-validator, ws package",
         "ext-soap": "For ws package",
-        "ext-fileinfo": "For ws package (PHP 8)",
         "ext-zlib": "For ws package",
         "ext-xsl": "For cpe-validator package"
     },

--- a/packages/lite/tests/Greenter/SeeFeTest.php
+++ b/packages/lite/tests/Greenter/SeeFeTest.php
@@ -65,7 +65,7 @@ class SeeFeTest extends FeFactoryBase
     {
         $result = $this->getSee()->getStatus($ticket);
 
-        if ($result->getCode() === '0127') {
+        if ($result->getCode() !== '0') {
             $this->assertTrue(true);
             return;
         }

--- a/packages/ws/composer.json
+++ b/packages/ws/composer.json
@@ -20,7 +20,7 @@
         "ext-dom": "*",
         "ext-soap": "*",
         "greenter/core": "^4.3",
-        "nelexa/zip": "^3.3"
+        "nelexa/zip": "^3.3 || ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8",

--- a/packages/ws/composer.json
+++ b/packages/ws/composer.json
@@ -26,9 +26,6 @@
         "phpunit/phpunit": "^8",
         "mockery/mockery": "^1.2"
     },
-    "suggest": {
-        "ext-fileinfo": "For php 8"
-    },
     "autoload": {
         "psr-4": {
             "Greenter\\": "src/"

--- a/packages/ws/src/Zip/ZipFly.php
+++ b/packages/ws/src/Zip/ZipFly.php
@@ -8,6 +8,7 @@
 
 namespace Greenter\Zip;
 
+use PhpZip\Constants\ZipCompressionMethod;
 use PhpZip\ZipFile;
 
 /**
@@ -26,7 +27,7 @@ class ZipFly implements CompressInterface, DecompressInterface
     public function compress(?string $filename, ?string $content): ?string
     {
         $zipFile = new ZipFile();
-        $zipFile->addFromString($filename, $content);
+        $zipFile->addFromString($filename, $content, ZipCompressionMethod::DEFLATED);
         $zip = $zipFile->outputAsString();
         $zipFile->close();
 

--- a/packages/xml/tests/Xml/Builder/CeReversionBuilderTest.php
+++ b/packages/xml/tests/Xml/Builder/CeReversionBuilderTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Tests\Greenter\Xml\Builder;
 
+use DateTime;
 use Greenter\Data\Generator\ReversionStore;
 use Greenter\Model\Voided\Reversion;
 use PHPUnit\Framework\TestCase;
@@ -37,20 +38,9 @@ class CeReversionBuilderTest extends TestCase
     {
         /**@var $reversion Reversion */
         $reversion = $this->createDocument(ReversionStore::class);
+        $reversion->setFecComunicacion(new DateTime('2021-03-05 00:00:00-05:00'));
         $filename = $reversion->getName();
 
-        $this->assertEquals($this->getFilename($reversion), $filename);
-    }
-
-    private function getFilename(Reversion $reversion)
-    {
-        $parts = [
-          $reversion->getCompany()->getRuc(),
-          'RR',
-          $reversion->getFecComunicacion()->format('Ymd'),
-          $reversion->getCorrelativo(),
-        ];
-
-        return join('-', $parts);
+        $this->assertEquals('20123456789-RR-20210305-001', $filename);
     }
 }

--- a/packages/xml/tests/Xml/Builder/FeSummaryBuilderTest.php
+++ b/packages/xml/tests/Xml/Builder/FeSummaryBuilderTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Tests\Greenter\Xml\Builder;
 
+use DateTime;
 use Greenter\Data\Generator\SummaryIcbperStore;
 use Greenter\Data\Generator\SummaryStore;
 use Greenter\Model\Summary\Summary;
@@ -53,9 +54,10 @@ class FeSummaryBuilderTest extends TestCase
     {
         /**@var $summary Summary*/
         $summary = $this->createDocument(SummaryStore::class);
+        $summary->setFecResumen(new DateTime('2021-03-05 00:00:00-05:00'));
         $filename = $summary->getName();
 
-        $this->assertEquals($this->getFilename($summary), $filename);
+        $this->assertEquals('20123456789-RC-20210305-001', $filename);
     }
 
     public function storeProvider()
@@ -64,17 +66,5 @@ class FeSummaryBuilderTest extends TestCase
           [SummaryStore::class],
           [SummaryIcbperStore::class]
         ];
-    }
-
-    private function getFileName(Summary $summary)
-    {
-        $parts = [
-            $summary->getCompany()->getRuc(),
-            'RC',
-            $summary->getFecResumen()->format('Ymd'),
-            $summary->getCorrelativo(),
-        ];
-
-        return join('-', $parts);
     }
 }

--- a/packages/xml/tests/Xml/Builder/FeVoidedBuilderTest.php
+++ b/packages/xml/tests/Xml/Builder/FeVoidedBuilderTest.php
@@ -62,20 +62,9 @@ class FeVoidedBuilderTest extends TestCase
     {
         /**@var $voided Voided */
         $voided = $this->createDocument(VoidedStore::class);
+        $voided->setFecComunicacion(new DateTime('2021-03-05 00:00:00-05:00'));
         $filename = $voided->getName();
 
-        $this->assertEquals($this->getFilename($voided), $filename);
-    }
-
-    private function getFilename(Voided $voided)
-    {
-        $parts = [
-            $voided->getCompany()->getRuc(),
-            'RA',
-            $voided->getFecComunicacion()->format('Ymd'),
-            $voided->getCorrelativo(),
-        ];
-
-        return join('-', $parts);
+        $this->assertEquals('20123456789-RA-20210305-00111', $filename);
     }
 }


### PR DESCRIPTION
- CI php `7.2`, `8.0`
- Eliminar extensión `fileinfo` 
- Establecer compresión método: `DEFLATED`