### PR TITLE
Se corrige el formateador de decimales para que permita enviar más de dos decimales

### DIFF
--- a/packages/xml/src/Xml/Filter/FormatFilter.php
+++ b/packages/xml/src/Xml/Filter/FormatFilter.php
@@ -18,7 +18,7 @@ class FormatFilter
         $numString = (string)$number;
         $applyFormat = $this->getDecimalsLength($numString) > $decimals || strpos($numString, "E") !== false;
 
-        return $applyFormat ? $this->number($number, $decimals) : $this->number($numString);
+        return $applyFormat ? $this->number($number, $decimals) : $number;
     }
 
     private function getDecimalsLength(string $number): int


### PR DESCRIPTION
Se corrige la funcion numberLimit para que no elimine los decimales si el valor es menor a "$decimals".

Ejemplo:
En algunos casos los XML tienen hasta 10 decimales psoibles. En invoice2.1.xml.tiwg en el PriceAmount se puede ver un caso. 

Sin embargo, si envias un número menor (por decir, 6 decimales) la función te devuelve 2 decimales por default, lo que hace imposible enviar más de dos decimales y menos de 10 decimales.

La corrección hace que, si la validación de que tiene más de X decimales es falsa, simplemente de devuela el número original, con los decimales que tenía, sin formatearlo.