### PR TITLE
añadir prefijo en Signature cbc:ID (para id signature) firmante externo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "mockery/mockery": "^1.2",
         "phpstan/phpstan": "^1.9",
         "phpunit/phpunit": "^9",
-        "vimeo/psalm": "^5.4"
+        "vimeo/psalm": "~5.10.0"
     },
     "suggest": {
         "ext-dom": "For xml, xml-parser, cpe-validator, ws package",

--- a/packages/xml/src/Xml/Templates/despatch.xml.twig
+++ b/packages/xml/src/Xml/Templates/despatch.xml.twig
@@ -29,7 +29,7 @@
     {% endif %}
     {% set emp = doc.company %}
     	<cac:Signature>
-		<cbc:ID>{{ emp.ruc }}</cbc:ID>
+		<cbc:ID>SIGN{{ emp.ruc }}</cbc:ID>
 		<cac:SignatoryParty>
 			<cac:PartyIdentification>
 				<cbc:ID>{{ emp.ruc }}</cbc:ID>

--- a/packages/xml/src/Xml/Templates/despatch2022.xml.twig
+++ b/packages/xml/src/Xml/Templates/despatch2022.xml.twig
@@ -31,7 +31,7 @@
     {% endfor %}
     {% set emp = doc.company %}
 	<cac:Signature>
-		<cbc:ID>{{ emp.ruc }}</cbc:ID>
+		<cbc:ID>SIGN{{ emp.ruc }}</cbc:ID>
 		<cac:SignatoryParty>
 			<cac:PartyIdentification>
 				<cbc:ID>{{ emp.ruc }}</cbc:ID>

--- a/packages/xml/src/Xml/Templates/invoice2.0.xml.twig
+++ b/packages/xml/src/Xml/Templates/invoice2.0.xml.twig
@@ -106,7 +106,7 @@
     {% endif %}
     {% set emp = doc.company %}
     <cac:Signature>
-        <cbc:ID>{{ emp.ruc }}</cbc:ID>
+        <cbc:ID>SIGN{{ emp.ruc }}</cbc:ID>
         <cac:SignatoryParty>
             <cac:PartyIdentification>
                 <cbc:ID>{{ emp.ruc }}</cbc:ID>

--- a/packages/xml/src/Xml/Templates/invoice2.1.xml.twig
+++ b/packages/xml/src/Xml/Templates/invoice2.1.xml.twig
@@ -59,7 +59,7 @@
     {% endfor %}
     {% endif %}
     <cac:Signature>
-        <cbc:ID>{{ emp.ruc }}</cbc:ID>
+        <cbc:ID>SIGN{{ emp.ruc }}</cbc:ID>
         <cac:SignatoryParty>
             <cac:PartyIdentification>
                 <cbc:ID>{{ emp.ruc }}</cbc:ID>

--- a/packages/xml/src/Xml/Templates/notacr2.0.xml.twig
+++ b/packages/xml/src/Xml/Templates/notacr2.0.xml.twig
@@ -90,7 +90,7 @@
     {% endif %}
     {% set emp = doc.company %}
     <cac:Signature>
-        <cbc:ID>{{ emp.ruc }}</cbc:ID>
+        <cbc:ID>SIGN{{ emp.ruc }}</cbc:ID>
         <cac:SignatoryParty>
             <cac:PartyIdentification>
                 <cbc:ID>{{ emp.ruc }}</cbc:ID>

--- a/packages/xml/src/Xml/Templates/notacr2.1.xml.twig
+++ b/packages/xml/src/Xml/Templates/notacr2.1.xml.twig
@@ -49,7 +49,7 @@
     {% endif %}
     {% set emp = doc.company %}
     <cac:Signature>
-        <cbc:ID>{{ emp.ruc }}</cbc:ID>
+        <cbc:ID>SIGN{{ emp.ruc }}</cbc:ID>
         <cac:SignatoryParty>
             <cac:PartyIdentification>
                 <cbc:ID>{{ emp.ruc }}</cbc:ID>

--- a/packages/xml/src/Xml/Templates/notadb2.0.xml.twig
+++ b/packages/xml/src/Xml/Templates/notadb2.0.xml.twig
@@ -82,7 +82,7 @@
     {% endif %}
     {% set emp = doc.company %}
     <cac:Signature>
-        <cbc:ID>{{ emp.ruc }}</cbc:ID>
+        <cbc:ID>SIGN{{ emp.ruc }}</cbc:ID>
         <cac:SignatoryParty>
             <cac:PartyIdentification>
                 <cbc:ID>{{ emp.ruc }}</cbc:ID>

--- a/packages/xml/src/Xml/Templates/notadb2.1.xml.twig
+++ b/packages/xml/src/Xml/Templates/notadb2.1.xml.twig
@@ -49,7 +49,7 @@
     {% endif %}
     {% set emp = doc.company %}
     <cac:Signature>
-        <cbc:ID>{{ emp.ruc }}</cbc:ID>
+        <cbc:ID>SIGN{{ emp.ruc }}</cbc:ID>
         <cac:SignatoryParty>
             <cac:PartyIdentification>
                 <cbc:ID>{{ emp.ruc }}</cbc:ID>

--- a/packages/xml/src/Xml/Templates/perception.xml.twig
+++ b/packages/xml/src/Xml/Templates/perception.xml.twig
@@ -10,7 +10,7 @@
 	<cbc:CustomizationID>1.0</cbc:CustomizationID>
     {% set emp = doc.company %}
 	<cac:Signature>
-		<cbc:ID>{{ emp.ruc }}</cbc:ID>
+		<cbc:ID>SIGN{{ emp.ruc }}</cbc:ID>
 		<cac:SignatoryParty>
 			<cac:PartyIdentification>
 				<cbc:ID>{{ emp.ruc }}</cbc:ID>

--- a/packages/xml/src/Xml/Templates/retention.xml.twig
+++ b/packages/xml/src/Xml/Templates/retention.xml.twig
@@ -10,7 +10,7 @@
     <cbc:CustomizationID>1.0</cbc:CustomizationID>
     {% set emp = doc.company %}
     <cac:Signature>
-        <cbc:ID>{{ emp.ruc }}</cbc:ID>
+        <cbc:ID>SIGN{{ emp.ruc }}</cbc:ID>
         <cac:SignatoryParty>
             <cac:PartyIdentification>
                 <cbc:ID>{{ emp.ruc }}</cbc:ID>

--- a/packages/xml/src/Xml/Templates/summary.xml.twig
+++ b/packages/xml/src/Xml/Templates/summary.xml.twig
@@ -13,7 +13,7 @@
     <cbc:IssueDate>{{ doc.fecResumen|date('Y-m-d') }}</cbc:IssueDate>
     {% set emp = doc.company %}
     <cac:Signature>
-        <cbc:ID>{{ emp.ruc }}</cbc:ID>
+        <cbc:ID>SIGN{{ emp.ruc }}</cbc:ID>
         <cac:SignatoryParty>
             <cac:PartyIdentification>
                 <cbc:ID>{{ emp.ruc }}</cbc:ID>

--- a/packages/xml/src/Xml/Templates/voided.xml.twig
+++ b/packages/xml/src/Xml/Templates/voided.xml.twig
@@ -13,7 +13,7 @@
     <cbc:IssueDate>{{ doc.fecComunicacion|date('Y-m-d') }}</cbc:IssueDate>
     {% set emp = doc.company %}
     <cac:Signature>
-        <cbc:ID>{{ emp.ruc }}</cbc:ID>
+        <cbc:ID>SIGN{{ emp.ruc }}</cbc:ID>
         <cac:SignatoryParty>
             <cac:PartyIdentification>
                 <cbc:ID>{{ emp.ruc }}</cbc:ID>


### PR DESCRIPTION
Para clientes nuevo RUS se puede dar el caso que no cuenten con CDT y requerimos firmar el comprobante externamente (QPse)
este añade el 
<ds:Signature Id="{{$id}}">
Este valor lo toma de 
<cbc:ID>SIGN{{ emp.ruc }}</cbc:ID>

![image](https://github.com/user-attachments/assets/d230c89c-573f-4142-897e-3cd9d66d45ad)

greenter colocaba el ruc de la empresa pero el primer campo debe seguir las reglas
valor del atributo Id: No empieza con un número.
Verifica la unicidad: Asegúrate de que el Id es único dentro del documento XML. No debe haber otro elemento con el mismo Id.
entonces he realizado este cambio añadiendo el prefijo.