### PR TITLE
Verificar los montos cuando son 0.00 no se añadia el taxsubtotal

### DIFF
--- a/packages/xml/src/Xml/Templates/invoice2.1.xml.twig
+++ b/packages/xml/src/Xml/Templates/invoice2.1.xml.twig
@@ -308,7 +308,7 @@
             </cac:TaxCategory>
         </cac:TaxSubtotal>
         {% endif %}
-        {% if doc.mtoOperGravadas %}
+        {% if doc.mtoOperGravadas is not null %}
         <cac:TaxSubtotal>
             <cbc:TaxableAmount currencyID="{{ doc.tipoMoneda }}">{{ doc.mtoOperGravadas|n_format }}</cbc:TaxableAmount>
             <cbc:TaxAmount currencyID="{{ doc.tipoMoneda }}">{{ doc.mtoIGV|n_format }}</cbc:TaxAmount>
@@ -321,7 +321,7 @@
             </cac:TaxCategory>
         </cac:TaxSubtotal>
         {% endif %}
-        {% if doc.mtoOperInafectas %}
+        {% if doc.mtoOperInafectas is not null %}
             <cac:TaxSubtotal>
                 <cbc:TaxableAmount currencyID="{{ doc.tipoMoneda }}">{{ doc.mtoOperInafectas|n_format }}</cbc:TaxableAmount>
                 <cbc:TaxAmount currencyID="{{ doc.tipoMoneda }}">0</cbc:TaxAmount>
@@ -334,7 +334,7 @@
                 </cac:TaxCategory>
             </cac:TaxSubtotal>
         {% endif %}
-        {% if doc.mtoOperExoneradas %}
+        {% if doc.mtoOperExoneradas is not null %}
             <cac:TaxSubtotal>
                 <cbc:TaxableAmount currencyID="{{ doc.tipoMoneda }}">{{ doc.mtoOperExoneradas|n_format }}</cbc:TaxableAmount>
                 <cbc:TaxAmount currencyID="{{ doc.tipoMoneda }}">0</cbc:TaxAmount>
@@ -347,7 +347,7 @@
                 </cac:TaxCategory>
             </cac:TaxSubtotal>
         {% endif %}
-        {% if doc.mtoOperGratuitas %}
+        {% if doc.mtoOperGratuitas is not null %}
             <cac:TaxSubtotal>
                 <cbc:TaxableAmount currencyID="{{ doc.tipoMoneda }}">{{ doc.mtoOperGratuitas|n_format }}</cbc:TaxableAmount>
                 <cbc:TaxAmount currencyID="{{ doc.tipoMoneda }}">{{ doc.mtoIGVGratuitas|n_format }}</cbc:TaxAmount>
@@ -360,7 +360,7 @@
                 </cac:TaxCategory>
             </cac:TaxSubtotal>
         {% endif %}
-        {% if doc.mtoOperExportacion %}
+        {% if doc.mtoOperExportacion is not null %}
             <cac:TaxSubtotal>
                 <cbc:TaxableAmount currencyID="{{ doc.tipoMoneda }}">{{ doc.mtoOperExportacion|n_format }}</cbc:TaxableAmount>
                 <cbc:TaxAmount currencyID="{{ doc.tipoMoneda }}">0</cbc:TaxAmount>

--- a/packages/xml/src/Xml/Templates/summary.xml.twig
+++ b/packages/xml/src/Xml/Templates/summary.xml.twig
@@ -68,13 +68,13 @@
             <cbc:ConditionCode>{{ det.estado }}</cbc:ConditionCode>
         </cac:Status>
         <sac:TotalAmount currencyID="{{ doc.moneda }}">{{ det.total|n_format }}</sac:TotalAmount>
-        {% if det.mtoOperGravadas %}
+        {% if det.mtoOperGravadas is not null  %}
         <sac:BillingPayment>
             <cbc:PaidAmount currencyID="{{ doc.moneda }}">{{ det.mtoOperGravadas|n_format }}</cbc:PaidAmount>
             <cbc:InstructionID>01</cbc:InstructionID>
         </sac:BillingPayment>
         {% endif %}
-        {% if det.mtoOperExoneradas %}
+        {% if det.mtoOperExoneradas  %}
         <sac:BillingPayment>
             <cbc:PaidAmount currencyID="{{ doc.moneda }}">{{ det.mtoOperExoneradas|n_format }}</cbc:PaidAmount>
             <cbc:InstructionID>02</cbc:InstructionID>


### PR DESCRIPTION
Solucion a cuando se emitia una factura/boleta con anticipo igual al monto a pagar dando resultado monto total 0.00
no se añadian los TaxSubtotal por 0.00

Issue #234 Anticipos 