### PR TITLE
guia remision transportista

### DIFF
--- a/packages/core/src/Core/Model/Despatch/Despatch.php
+++ b/packages/core/src/Core/Model/Despatch/Despatch.php
@@ -406,4 +406,29 @@ class Despatch implements DocumentInterface
 
         return join('-', $parts);
     }
+
+    //Extra para guia transportista
+    /**
+    * @var Client
+    */
+    private $remitente;
+        /**
+     * @return Client
+     */
+    public function getRemitente(): ?Client
+    {
+        return $this->remitente;
+    }
+
+    /**
+     * @param Client $remitente
+     *
+     * @return Despatch
+     */
+    public function setRemitente(?Client $remitente): Despatch
+    {
+        $this->remitente = $remitente;
+
+        return $this;
+    }
 }

--- a/packages/core/src/Core/Model/Despatch/Shipment.php
+++ b/packages/core/src/Core/Model/Despatch/Shipment.php
@@ -545,4 +545,29 @@ class Shipment
 
         return $this;
     }
+    
+    //Extra para guia transportista
+    /**
+    * @var Transportist
+    */
+    private $subContratado;
+        /**
+     * @return Transportist
+     */
+    public function getSubContratado(): ?Transportist
+    {
+        return $this->subContratado;
+    }
+
+    /**
+     * @param Transportist $subContratado
+     *
+     * @return Despatch
+     */
+    public function setSubContratado(?Transportist $subContratado): Shipment
+    {
+        $this->subContratado = $subContratado;
+
+        return $this;
+    }
 }

--- a/packages/xml/src/Xml/Templates/despatch2022.xml.twig
+++ b/packages/xml/src/Xml/Templates/despatch2022.xml.twig
@@ -110,6 +110,21 @@
 		{% for indicador in envio.indicadores %}
 		<cbc:SpecialInstructions>{{ indicador }}</cbc:SpecialInstructions>
 		{% endfor %}
+		{% if envio.subContratado %}
+		<cac:Consignment>
+	        <!-- ID OBLIGATORIO POR UBL -->
+			<cbc:ID>SUNAT_Envio</cbc:ID>
+			<!-- DATOS DEL SUBCONTRATADOR -->
+        	<cac:LogisticsOperatorParty>
+			   <cac:PartyIdentification>
+				  <cbc:ID schemeID="{{ envio.subContratado.tipoDoc }}" schemeName="Documento de Identidad" schemeAgencyName="PE:SUNAT" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">{{ envio.subContratado.numDoc }}</cbc:ID>
+			   </cac:PartyIdentification>
+			   <cac:PartyLegalEntity>
+				  <cbc:RegistrationName><![CDATA[{{ envio.subContratado.rznSocial|raw }}]]></cbc:RegistrationName>
+			   </cac:PartyLegalEntity>
+			</cac:LogisticsOperatorParty>
+		</cac:Consignment>
+		{% endif %}
 		<cac:ShipmentStage>
 			<cbc:TransportModeCode listName="Modalidad de traslado" listAgencyName="PE:SUNAT" listURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo18">{{ envio.modTraslado }}</cbc:TransportModeCode>
 			{% if envio.fecTraslado %}
@@ -160,6 +175,17 @@
 						<cbc:Line>{{ envio.partida.direccion }}</cbc:Line>
 					</cac:AddressLine>
 				</cac:DespatchAddress>
+				{% if doc.remitente %}
+				<cac:DespatchParty>
+					<cac:PartyIdentification>
+						<cbc:ID schemeID="6" schemeName="Documento de Identidad" schemeAgencyName="PE:SUNAT"
+								schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">{{ doc.remitente.numDoc|raw }}</cbc:ID>
+					</cac:PartyIdentification>
+					<cac:PartyLegalEntity>
+						<cbc:RegistrationName><![CDATA[{{ doc.remitente.rznSocial }}]]></cbc:RegistrationName>
+					</cac:PartyLegalEntity>
+				</cac:DespatchParty>
+				{% endif %}
 			</cac:Despatch>
 		</cac:Delivery>
 		{% for precinto in envio.contenedores %}
@@ -246,4 +272,4 @@
 	</cac:DespatchLine>
     {% endfor %}
 </DespatchAdvice>
-{% endapply %}
+ {% endapply %}


### PR DESCRIPTION
Valido para guia de transportista (codigo 31 del catalogo), incluye:

Propiedad Remitente (necesario para gre de transportista)
![image](https://github.com/user-attachments/assets/8fa51ace-9422-41a1-a951-f7cea235b95b)

Propiedad Subcontratado, se usa cuando el transportista va a sub-contratar a otra empresa de transporte quien realizará el transporte final
![image](https://github.com/user-attachments/assets/56de07f6-0665-401a-88c4-a4d30847313c)
