### PR TITLE
Amplía compatibilidad con bacon/bacon-qr-code ^3.0

### DIFF
--- a/packages/report/composer.json
+++ b/packages/report/composer.json
@@ -18,7 +18,7 @@
         "php": ">=7.4",
         "twig/twig": "~3.0",
         "greenter/core": "^5.0",
-        "bacon/bacon-qr-code": "^2.0"
+        "bacon/bacon-qr-code": "^2.0|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",


### PR DESCRIPTION
Agrega compatibilidad con `bacon/bacon-qr-code` ^3.0, requerida por versiones modernas de Laravel. Probado localmente sin errores.