### PR TITLE
Terminar compatibilidad con/bacon-qr-code 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,12 @@
 {
     "name": "greenter/greenter",
     "description": "Facturacion Electrónica SUNAT en Perú",
-    "keywords": ["facturacion-electronica", "sunat", "peru", "greenter"],
+    "keywords": [
+        "facturacion-electronica",
+        "sunat",
+        "peru",
+        "greenter"
+    ],
     "homepage": "https://greenter.dev/",
     "license": "MIT",
     "authors": [
@@ -21,7 +26,7 @@
     ],
     "require": {
         "php": ">=7.4",
-        "bacon/bacon-qr-code": "^2.0",
+        "bacon/bacon-qr-code": "^2.0|^3.0",
         "greenter/gre-api": "^1.0",
         "greenter/xmldsig": "^5.0",
         "mikehaertl/phpwkhtmltopdf": "^2.4",


### PR DESCRIPTION
Soluciona la instalacion de greenter en versiones php 8 y superiores, que ya no soportan bacon 2.0.
report se actualizo pero si no se actualizaba aqui no dejaba instalar