### PR TITLE
feat: add optional porcentajeIgv (#266)

### DIFF
--- a/packages/core/src/Core/Model/Summary/SummaryDetail.php
+++ b/packages/core/src/Core/Model/Summary/SummaryDetail.php
@@ -63,6 +63,11 @@ class SummaryDetail
     private $total;
 
     /**
+     * @var ?float
+     */
+    private ?float $porcentajeIgv = null;
+
+    /**
      * @var float
      */
     private $mtoOperGravadas;
@@ -275,6 +280,26 @@ class SummaryDetail
     public function setTotal(?float $total): SummaryDetail
     {
         $this->total = $total;
+
+        return $this;
+    }
+
+    /**
+     * @return float
+     */
+    public function getPorcentajeIgv(): ?float
+    {
+        return $this->porcentajeIgv;
+    }
+
+    /**
+     * @param float $porcentajeIgv
+     *
+     * @return SummaryDetail
+     */
+    public function setPorcentajeIgv(?float $porcentajeIgv): SummaryDetail
+    {
+        $this->porcentajeIgv = $porcentajeIgv;
 
         return $this;
     }

--- a/packages/data/src/Data/Generator/SummaryStore.php
+++ b/packages/data/src/Data/Generator/SummaryStore.php
@@ -45,6 +45,7 @@ class SummaryStore implements DocumentGeneratorInterface
             ->setMtoOperExoneradas(50)
             ->setMtoOperExportacion(10)
             ->setMtoOtrosCargos(21)
+            ->setPorcentajeIgv(18.0)
             ->setMtoIGV(3.6);
 
         $detiail2 = new SummaryDetail();
@@ -62,6 +63,7 @@ class SummaryStore implements DocumentGeneratorInterface
             ->setMtoOperInafectas(120)
             ->setMtoOperGratuitas(10)
             ->setMtoIGV(7.2)
+            ->setPorcentajeIgv(18.0)
             ->setMtoISC(2.8);
 
         $detiail3 = new SummaryDetail();
@@ -81,7 +83,8 @@ class SummaryStore implements DocumentGeneratorInterface
             ->setMtoOperInafectas(24.4)
             ->setMtoOperExoneradas(50)
             ->setMtoOtrosCargos(21)
-            ->setMtoIGV(3.6);
+            ->setMtoIGV(3.6)
+            ->setPorcentajeIgv(18.0);
 
         $detiail4 = new SummaryDetail();
         $detiail4->setTipoDoc('03')

--- a/packages/lite/tests/Greenter/Factory/FeFactoryBase.php
+++ b/packages/lite/tests/Greenter/Factory/FeFactoryBase.php
@@ -351,7 +351,8 @@ class FeFactoryBase extends TestCase
             ->setMtoOperGravadas(20)
             ->setMtoOperInafectas(12)
             ->setMtoOperExoneradas(15)
-            ->setMtoIGV(3.6);
+            ->setMtoIGV(3.6)
+            ->setPorcentajeIgv(18.0);
 
         $detiail2 = new SummaryDetail();
         $detiail2->setTipoDoc('03')
@@ -371,6 +372,7 @@ class FeFactoryBase extends TestCase
             ->setMtoOperInafectas(20)
             ->setMtoOtrosCargos(10)
             ->setMtoIGV(42.12)
+            ->setPorcentajeIgv(18.0)
             ->setMtoISC(34);
 
         $sum = new Summary();

--- a/packages/xml/src/Xml/Templates/summary.xml.twig
+++ b/packages/xml/src/Xml/Templates/summary.xml.twig
@@ -126,6 +126,9 @@
             <cac:TaxSubtotal>
                 <cbc:TaxAmount currencyID="{{ doc.moneda }}">{{ igv }}</cbc:TaxAmount>
                 <cac:TaxCategory>
+                    {% if det.porcentajeIgv is not null %}
+                        <cbc:Percent>{{ det.porcentajeIgv|n_format }}</cbc:Percent>
+                    {% endif %}
                     <cac:TaxScheme>
                         <cbc:ID>1000</cbc:ID>
                         <cbc:Name>IGV</cbc:Name>


### PR DESCRIPTION
Este PR resuelve el issue #266 agregando soporte para el campo porcentajeIgv en SummaryDetail.

Actualmente, en el detalle del Resumen Diario (SummaryDocumentsLine) se informa el monto del IGV (mtoIGV), pero no se incluye explícitamente el porcentaje aplicado (cbc:Percent).
Según las actualizaciones recientes de SUNAT, este porcentaje debe declararse en el XML para evitar el error 2992.

**Cambios realizados**

- Se agregó la propiedad opcional porcentajeIgv en Greenter\Model\Summary\SummaryDetail.
- Se implementaron los métodos:
   - getPorcentajeIgv(): ?float
   - setPorcentajeIgv(?float $porcentajeIgv)
- Se actualizó el template summary.xml.twig para incluir el nodo:
`<cbc:Percent>{{ det.porcentajeIgv }}</cbc:Percent>
`
- El campo se implementó como opcional para mantener compatibilidad hacia atrás.
- Se verificó que todos los tests existentes pasen correctamente.

**Compatibilidad**
- El cambio es retrocompatible:
- Si no se establece porcentajeIgv, la generación del XML no falla.
- No afecta implementaciones actuales que no utilicen este campo.